### PR TITLE
Update docs + pre wrap

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,13 +9,13 @@
     <meta property="og:site_name" content="TextLayoutBuilder"/>
     <meta property="og:title" content="TextLayoutBuilder | Build text Layouts easily on Android." />
     <meta property="og:image" content="http://facebookincubator.github.io/TextLayoutBuilder/logo.png" />
-    <meta property="og:description" content="TextLayoutBuilder is an utility to build text Layouts easily on Android." />
+    <meta property="og:description" content="TextLayoutBuilder is a utility to build text layouts easily on Android." />
 
     <link rel="stylesheet" href="./main.css" media="screen">
     <link rel="icon" href="./favicon.png" type="image/x-icon">
 
     <title>TextLayoutBuilder</title>
-    <meta name="description" content="TextLayoutBuilder is an utility to build text Layouts easily on Android.">
+    <meta name="description" content="TextLayoutBuilder is a utility to build text layouts easily on Android.">
 
     <link rel="canonical" href="http://facebookincubator.github.io/TextLayoutBuilder">
   </head>
@@ -48,7 +48,7 @@
     <div class="contentsContainer">
       <div class="wrapper">
         <section>
-          <h2>Build text Layouts easily on Android!</h2>
+          <h2>Build text layouts easily on Android!</h2>
           <div class="introContainer">
             <div class="intro">
               <p><code>TextLayoutBuilder</code> uses a builder pattern to configure the properties
@@ -57,10 +57,10 @@
                 <code>TextLayoutBuilder</code> creates a text <code>Layout</code> based on
                 the properties set on it.</p>
               <ul>
-                <li>Allows creating text <code>Layout</code>s easily</li>
-                <li>Re-use the same builder to create <code>Layout</code>s of similar style</li>
-                <li>Cache <code>Layout</code>s of commonly used strings</li>
-                <li>Glyph warming to improve performance</li>
+                <li>Create text layouts easily.</li>
+                <li>Reuse the same builder to create layouts of similar style.</li>
+                <li>Cache layouts of commonly used strings.</li>
+                <li>Improve performance with glyph warming.</li>
               </ul>
             </div>
             <div class="intro">
@@ -99,7 +99,7 @@ Layout layout = new TextLayoutBuilder()
             <div class="feature">
               <h4>Glyph Warming</h4>
               <p>On 4.0+ devices, Android uses a texture cache to warm up the glyphs. By drawing these
-                glyphs on a background thread on to a <code>Picture</code>, <code>TextLayoutBuilder</code> warms
+                glyphs on a background thread onto a <code>Picture</code>, <code>TextLayoutBuilder</code> warms
                 these glyphs and can help them render at 0ms.</p>
             </div>
           </div>
@@ -107,8 +107,32 @@ Layout layout = new TextLayoutBuilder()
       </div>
     </div>
 
-    <!-- Instructions -->
+    <!-- Download -->
     <div class="instructionsContainer alternate">
+      <div class="wrapper">
+        <section>
+          <h3>Download</h3>
+          <ul>
+            <li>
+              Grab via Gradle:
+              <pre>compile 'com.facebook.fbui.textlayoutbuilder:textlayoutbuilder:1.0.0'</pre>
+            </li>
+            <li>
+              or Maven:
+              <pre>
+&lt;dependency&gt;
+    &lt;groupId&gt;com.facebook.fbui.textlayoutbuilder&lt;/groupId&gt;
+    &lt;artifactId&gt;textlayoutbuilder&lt;/artifactId&gt;
+    &lt;version&gt;1.0.0&lt;/version&gt;
+&lt;/dependency&gt;</pre>
+            </li>
+          </ul>
+        </section>
+      </div>
+    </div>
+
+    <!-- Instructions -->
+    <div class="instructionsContainer">
       <div class="wrapper">
         <section>
           <h3>Usage</h3>
@@ -139,7 +163,7 @@ TextLayoutBuilder builder = new TextLayoutBuilder()
     </div>
 
     <!-- Additional Usage -->
-    <div class="instructionsContainer">
+    <div class="instructionsContainer alternate">
       <div class="wrapper">
         <section>
           <h3>Additional Usage</h3>
@@ -169,44 +193,29 @@ ResourceTextLayoutHelper.updateFromStyleResource(
       </div>
     </div>
 
-    <!-- Download -->
-    <div class="instructionsContainer alternate">
-      <div class="wrapper">
-        <section>
-          <h3>Download</h3>
-          <ul>
-            <li>
-              Grab via Gradle:
-              <pre>compile 'com.facebook.fbui.textlayoutbuilder:textlayoutbuilder:1.0.0'</pre>
-            </li>
-            <li>
-              or Maven:
-              <pre>
-&lt;dependency&gt;
-    &lt;groupId&gt;com.facebook.fbui.textlayoutbuilder&lt;/groupId&gt;
-    &lt;artifactId&gt;textlayoutbuilder&lt;/artifactId&gt;
-    &lt;version&gt;1.0.0&lt;/version&gt;
-&lt;/dependency&gt;</pre>
-            </li>
-          </ul>
-        </section>
-      </div>
-    </div>
-
     <!-- Footer -->
     <div class="footerContainer">
       <footer class="wrapper">
-        <div class="fboss">
-          <svg class="facebookOSSLogoSvg" viewBox="0 0 1133.9 1133.9" x="0px" y="0px">
-            <g>
-              <path class="logoRing outerRing" d="M 498.3 3.7 c 153.6 88.9 307.3 177.7 461.1 266.2 c 7.6 4.4 10.3 9.1 10.3 17.8 c -0.3 179.1 -0.2 358.3 0 537.4 c 0 8.1 -2.4 12.8 -9.7 17.1 c -154.5 88.9 -308.8 178.1 -462.9 267.5 c -9 5.2 -15.5 5.3 -24.6 0.1 c -153.9 -89.2 -307.9 -178 -462.1 -266.8 C 3 838.8 0 833.9 0 825.1 c 0.3 -179.1 0.2 -358.3 0 -537.4 c 0 -8.6 2.6 -13.6 10.2 -18 C 164.4 180.9 318.4 92 472.4 3 C 477 -1.5 494.3 -0.7 498.3 3.7 Z M 48.8 555.3 c 0 79.9 0.2 159.9 -0.2 239.8 c -0.1 10 3 15.6 11.7 20.6 c 137.2 78.8 274.2 157.8 411 237.3 c 9.9 5.7 17 5.7 26.8 0.1 c 137.5 -79.8 275.2 -159.2 412.9 -238.5 c 7.4 -4.3 10.5 -8.9 10.5 -17.8 c -0.3 -160.2 -0.3 -320.5 0 -480.7 c 0 -8.8 -2.8 -13.6 -10.3 -18 C 772.1 218 633.1 137.8 494.2 57.4 c -6.5 -3.8 -11.5 -4.5 -18.5 -0.5 C 336.8 137.4 197.9 217.7 58.8 297.7 c -7.7 4.4 -10.2 9.2 -10.2 17.9 C 48.9 395.5 48.8 475.4 48.8 555.3 Z" />
-              <path class="logoRing middleRing" d="M 184.4 555.9 c 0 -33.3 -1 -66.7 0.3 -100 c 1.9 -48 24.1 -86 64.7 -110.9 c 54.8 -33.6 110.7 -65.5 167 -96.6 c 45.7 -25.2 92.9 -24.7 138.6 1 c 54.4 30.6 108.7 61.5 162.2 93.7 c 44 26.5 67.3 66.8 68 118.4 c 0.9 63.2 0.9 126.5 0 189.7 c -0.7 50.6 -23.4 90.7 -66.6 116.9 c -55 33.4 -110.8 65.4 -167.1 96.5 c -43.4 24 -89 24.2 -132.3 0.5 c -57.5 -31.3 -114.2 -64 -170 -98.3 c -41 -25.1 -62.9 -63.7 -64.5 -112.2 C 183.5 621.9 184.3 588.9 184.4 555.9 Z M 232.9 556.3 c 0 29.5 0.5 59.1 -0.1 88.6 c -0.8 39.2 16.9 67.1 50.2 86.2 c 51.2 29.4 102.2 59.2 153.4 88.4 c 31.4 17.9 63.6 18.3 95 0.6 c 53.7 -30.3 107.1 -61.2 160.3 -92.5 c 29.7 -17.5 45 -44.5 45.3 -78.8 c 0.6 -61.7 0.5 -123.5 0 -185.2 c -0.3 -34.4 -15.3 -61.5 -44.9 -79 C 637.7 352.6 583 320.8 527.9 290 c -27.5 -15.4 -57.2 -16.1 -84.7 -0.7 c -56.9 31.6 -113.4 64 -169.1 97.6 c -26.4 15.9 -40.7 41.3 -41.1 72.9 C 232.6 491.9 232.9 524.1 232.9 556.3 Z" />
-              <path class="logoRing innerRing" d="M 484.9 424.4 c 69.8 -2.8 133.2 57.8 132.6 132 C 617 630 558.5 688.7 484.9 689.1 c -75.1 0.4 -132.6 -63.6 -132.7 -132.7 C 352.1 485 413.4 421.5 484.9 424.4 Z M 401.3 556.7 c -3.4 37.2 30.5 83.6 83 84.1 c 46.6 0.4 84.8 -37.6 84.9 -84 c 0.1 -46.6 -37.2 -84.4 -84.2 -84.6 C 432.2 472.1 397.9 518.3 401.3 556.7 Z" />
-            </g>
-          </svg>
-          <h2>Facebook Open Source</h2>
-        </div>
-        <div class="spacer"></div>
+        <nav>
+          <ul>
+            <li>
+              <div class="fboss">
+                <a href="https://code.facebook.com/projects/">
+                  <svg class="facebookOSSLogoSvg" viewBox="0 0 1133.9 1133.9" x="0px" y="0px">
+                    <g>
+                      <path class="logoRing outerRing" d="M 498.3 3.7 c 153.6 88.9 307.3 177.7 461.1 266.2 c 7.6 4.4 10.3 9.1 10.3 17.8 c -0.3 179.1 -0.2 358.3 0 537.4 c 0 8.1 -2.4 12.8 -9.7 17.1 c -154.5 88.9 -308.8 178.1 -462.9 267.5 c -9 5.2 -15.5 5.3 -24.6 0.1 c -153.9 -89.2 -307.9 -178 -462.1 -266.8 C 3 838.8 0 833.9 0 825.1 c 0.3 -179.1 0.2 -358.3 0 -537.4 c 0 -8.6 2.6 -13.6 10.2 -18 C 164.4 180.9 318.4 92 472.4 3 C 477 -1.5 494.3 -0.7 498.3 3.7 Z M 48.8 555.3 c 0 79.9 0.2 159.9 -0.2 239.8 c -0.1 10 3 15.6 11.7 20.6 c 137.2 78.8 274.2 157.8 411 237.3 c 9.9 5.7 17 5.7 26.8 0.1 c 137.5 -79.8 275.2 -159.2 412.9 -238.5 c 7.4 -4.3 10.5 -8.9 10.5 -17.8 c -0.3 -160.2 -0.3 -320.5 0 -480.7 c 0 -8.8 -2.8 -13.6 -10.3 -18 C 772.1 218 633.1 137.8 494.2 57.4 c -6.5 -3.8 -11.5 -4.5 -18.5 -0.5 C 336.8 137.4 197.9 217.7 58.8 297.7 c -7.7 4.4 -10.2 9.2 -10.2 17.9 C 48.9 395.5 48.8 475.4 48.8 555.3 Z" />
+                      <path class="logoRing middleRing" d="M 184.4 555.9 c 0 -33.3 -1 -66.7 0.3 -100 c 1.9 -48 24.1 -86 64.7 -110.9 c 54.8 -33.6 110.7 -65.5 167 -96.6 c 45.7 -25.2 92.9 -24.7 138.6 1 c 54.4 30.6 108.7 61.5 162.2 93.7 c 44 26.5 67.3 66.8 68 118.4 c 0.9 63.2 0.9 126.5 0 189.7 c -0.7 50.6 -23.4 90.7 -66.6 116.9 c -55 33.4 -110.8 65.4 -167.1 96.5 c -43.4 24 -89 24.2 -132.3 0.5 c -57.5 -31.3 -114.2 -64 -170 -98.3 c -41 -25.1 -62.9 -63.7 -64.5 -112.2 C 183.5 621.9 184.3 588.9 184.4 555.9 Z M 232.9 556.3 c 0 29.5 0.5 59.1 -0.1 88.6 c -0.8 39.2 16.9 67.1 50.2 86.2 c 51.2 29.4 102.2 59.2 153.4 88.4 c 31.4 17.9 63.6 18.3 95 0.6 c 53.7 -30.3 107.1 -61.2 160.3 -92.5 c 29.7 -17.5 45 -44.5 45.3 -78.8 c 0.6 -61.7 0.5 -123.5 0 -185.2 c -0.3 -34.4 -15.3 -61.5 -44.9 -79 C 637.7 352.6 583 320.8 527.9 290 c -27.5 -15.4 -57.2 -16.1 -84.7 -0.7 c -56.9 31.6 -113.4 64 -169.1 97.6 c -26.4 15.9 -40.7 41.3 -41.1 72.9 C 232.6 491.9 232.9 524.1 232.9 556.3 Z" />
+                      <path class="logoRing innerRing" d="M 484.9 424.4 c 69.8 -2.8 133.2 57.8 132.6 132 C 617 630 558.5 688.7 484.9 689.1 c -75.1 0.4 -132.6 -63.6 -132.7 -132.7 C 352.1 485 413.4 421.5 484.9 424.4 Z M 401.3 556.7 c -3.4 37.2 30.5 83.6 83 84.1 c 46.6 0.4 84.8 -37.6 84.9 -84 c 0.1 -46.6 -37.2 -84.4 -84.2 -84.6 C 432.2 472.1 397.9 518.3 401.3 556.7 Z" />
+                    </g>
+                  </svg>
+                <h2>Facebook Open Source</h2>
+              </a>
+            </div>
+          </li>
+        </ul>
+      </nav>
+
+      <div class="spacer"></div>
         <nav>
           <ul>
             <li>
@@ -217,7 +226,7 @@ ResourceTextLayoutHelper.updateFromStyleResource(
             </li>
           </ul>
         </nav>
-        <div class="spacer"></div>
+      <div class="spacer"></div>
         <nav>
           <ul>
             <li>

--- a/docs/main.css
+++ b/docs/main.css
@@ -306,6 +306,11 @@ pre {
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.26);
   line-height: 1.5em;
   font-family: Consolas, Monaco, Menlo, monospace;
+  white-space: pre-wrap;       /* CSS 3 */
+  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+  white-space: -pre-wrap;      /* Opera 4-6 */
+  white-space: -o-pre-wrap;    /* Opera 7 */
+  word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
 pre.highlight {
   background-color: #fff;


### PR DESCRIPTION
Update the docs a bit
- consistency on the bullets by starting with verb
- Moved Download section before Usage
- editorial changes
- make Facebook Open Source in footer a link

Added `pre-wrap` for pre blocks so that it can wrap
on mobile devices as needed.

![screencapture-0-0-0-0-8000-1481749720751](https://cloud.githubusercontent.com/assets/3757713/21201109/88683810-c1fe-11e6-87b1-18e8e608c613.png)

![screencapture-0-0-0-0-8000-1481749734871](https://cloud.githubusercontent.com/assets/3757713/21201116/90217206-c1fe-11e6-96b0-a01fb5ffb763.png)

![screencapture-0-0-0-0-8000-1481749746379](https://cloud.githubusercontent.com/assets/3757713/21201121/92c9fe38-c1fe-11e6-8a74-0f5b8aff84ed.png)
