### PR TITLE
Use the new StaticLayout.Builder API on 23+

### DIFF
--- a/library/libs/proxy/build.gradle
+++ b/library/libs/proxy/build.gradle
@@ -10,7 +10,7 @@ targetCompatibility = 1.7
 
 jar {
     baseName = 'staticlayout-proxy'
-    version = '1.0'
+    version = '1.1'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/library/libs/proxy/src/main/java/com/facebook/fbui/textlayoutbuilder/proxy/StaticLayoutProxy.java
+++ b/library/libs/proxy/src/main/java/com/facebook/fbui/textlayoutbuilder/proxy/StaticLayoutProxy.java
@@ -72,7 +72,7 @@ public class StaticLayoutProxy {
     }
   }
 
-  private static TextDirectionHeuristic fromTextDirectionHeuristicCompat(
+  public static TextDirectionHeuristic fromTextDirectionHeuristicCompat(
       TextDirectionHeuristicCompat textDirection) {
     if (textDirection == TextDirectionHeuristicsCompat.LTR) {
       return TextDirectionHeuristics.LTR;

--- a/library/src/main/java/com/facebook/fbui/textlayoutbuilder/StaticLayoutHelper.java
+++ b/library/src/main/java/com/facebook/fbui/textlayoutbuilder/StaticLayoutHelper.java
@@ -9,6 +9,7 @@
 
 package com.facebook.fbui.textlayoutbuilder;
 
+import android.os.Build;
 import android.support.v4.text.TextDirectionHeuristicCompat;
 import android.text.Layout;
 import android.text.StaticLayout;
@@ -149,6 +150,10 @@ import java.lang.reflect.Field;
    * @param ellipsisWidth The width of the ellipsis
    * @param maxLines The maximum number of lines for this layout
    * @param textDirection The text direction
+   * @param breakStrategy The break strategy
+   * @param hyphenationFrequency The hyphenation frequency
+   * @param leftIndents The array of left indent margins in pixels
+   * @param rightIndents The array of left indent margins in pixels
    * @return A {@link StaticLayout}
    */
   public static StaticLayout make(
@@ -164,7 +169,27 @@ import java.lang.reflect.Field;
       TextUtils.TruncateAt ellipsize,
       int ellipsisWidth,
       int maxLines,
-      TextDirectionHeuristicCompat textDirection) {
+      TextDirectionHeuristicCompat textDirection,
+      int breakStrategy,
+      int hyphenationFrequency,
+      int[] leftIndents,
+      int[] rightIndents) {
+
+    // Use the new Builder on 23+.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return StaticLayout.Builder.obtain(text, start, end, paint, width)
+          .setAlignment(alignment)
+          .setLineSpacing(spacingAdd, spacingMult)
+          .setIncludePad(includePadding)
+          .setEllipsize(ellipsize)
+          .setEllipsizedWidth(ellipsisWidth)
+          .setMaxLines(maxLines)
+          .setTextDirection(StaticLayoutProxy.fromTextDirectionHeuristicCompat(textDirection))
+          .setBreakStrategy(breakStrategy)
+          .setHyphenationFrequency(hyphenationFrequency)
+          .setIndents(leftIndents, rightIndents)
+          .build();
+    }
 
     StaticLayout layout = getStaticLayoutMaybeMaxLines(
         text,

--- a/library/src/main/java/com/facebook/fbui/textlayoutbuilder/TextLayoutBuilder.java
+++ b/library/src/main/java/com/facebook/fbui/textlayoutbuilder/TextLayoutBuilder.java
@@ -92,6 +92,11 @@ public class TextLayoutBuilder {
     TextDirectionHeuristicCompat textDirection =
         TextDirectionHeuristicsCompat.FIRSTSTRONG_LTR;
 
+    int breakStrategy = 0;
+    int hyphenationFrequency = 0;
+    int[] leftIndents;
+    int[] rightIndents;
+
     boolean mForceNewPaint = false;
 
     /**
@@ -126,6 +131,26 @@ public class TextLayoutBuilder {
       hashCode = 31 * hashCode + maxLines;
       hashCode = 31 * hashCode + (alignment != null ? alignment.hashCode() : 0);
       hashCode = 31 * hashCode + (textDirection != null ? textDirection.hashCode() : 0);
+      hashCode = 31 * hashCode + breakStrategy;
+      hashCode = 31 * hashCode + hyphenationFrequency;
+      hashCode = 31 * hashCode + breakStrategy;
+
+      if (leftIndents == null) {
+        hashCode = 31 * hashCode + 0;
+      } else {
+        for (int i = 0; i < leftIndents.length; i++) {
+          hashCode = 31 * hashCode + leftIndents[i];
+        }
+      }
+
+      if (rightIndents == null) {
+        hashCode = 31 * hashCode + 0;
+      } else {
+        for (int i = 0; i < rightIndents.length; i++) {
+          hashCode = 31 * hashCode + rightIndents[i];
+        }
+      }
+
       hashCode = 31 * hashCode + (text != null ? text.hashCode() : 0);
 
       return hashCode;
@@ -563,6 +588,87 @@ public class TextLayoutBuilder {
   }
 
   /**
+   * Returns the break strategy for this TextLayoutBuilder.
+   *
+   * @return The break strategy for this TextLayoutBuilder
+   */
+  public int getBreakStrategy() {
+    return mParams.breakStrategy;
+  }
+
+  /**
+   * Sets a break strategy breaking paragraphs into lines.
+   *
+   * @param breakStrategy The break strategy for breaking paragraphs into lines
+   * @return This {@link TextLayoutBuilder} instance
+   */
+  public TextLayoutBuilder setBreakStrategy(int breakStrategy) {
+    if (mParams.breakStrategy != breakStrategy) {
+      mParams.breakStrategy = breakStrategy;
+      mSavedLayout = null;
+    }
+    return this;
+  }
+
+  /**
+   * Returns the hyphenation frequency for this TextLayoutBuilder.
+   *
+   * @return The hyphenation frequency for this TextLayoutBuilder
+   */
+  public int getHyphenationFrequency() {
+    return mParams.hyphenationFrequency;
+  }
+
+  /**
+   * Sets the frequency of automatic hyphenation to use when determining word breaks.
+   *
+   * @param hyphenationFrequency The frequency of automatic hyphenation to use for word breaks
+   * @return This {@link TextLayoutBuilder} instance
+   */
+  public TextLayoutBuilder setHyphenationFrequency(int hyphenationFrequency) {
+    if (mParams.hyphenationFrequency != hyphenationFrequency) {
+      mParams.hyphenationFrequency = hyphenationFrequency;
+      mSavedLayout = null;
+    }
+    return this;
+  }
+
+  /**
+   * Returns the left indents set on this TextLayoutBuilder.
+   *
+   * @return The left indents set on this TextLayoutBuilder
+   */
+  public int[] getLeftIndents() {
+    return mParams.leftIndents;
+  }
+
+  /**
+   * Returns the right indents set on this TextLayoutBuilder.
+   *
+   * @return The right indents set on this TextLayoutBuilder
+   */
+  public int[] getRightIndents() {
+    return mParams.rightIndents;
+  }
+
+  /**
+   * Sets the left and right indents for this TextLayoutBuilder.
+   * <p>
+   * The arrays hold an indent amount, one per line, measured in pixels.
+   * For lines past the last element in the array, the last element repeats.
+   *
+   * @param leftIndents The left indents for the paragraph
+   * @param rightIndents The left indents for the paragraph
+   * @return This {@link TextLayoutBuilder} instance
+   */
+  public TextLayoutBuilder setIndents(int[] leftIndents, int[] rightIndents) {
+    mParams.leftIndents = leftIndents;
+    mParams.rightIndents = rightIndents;
+    mSavedLayout = null;
+    return this;
+  }
+
+  /**
    * Returns whether the TextLayoutBuilder should cache the layout.
    *
    * @return Whether the TextLayoutBuilder should cache the layout
@@ -836,7 +942,11 @@ public class TextLayoutBuilder {
               mParams.ellipsize,
               width,
               numLines,
-              mParams.textDirection);
+              mParams.textDirection,
+              mParams.breakStrategy,
+              mParams.hyphenationFrequency,
+              mParams.leftIndents,
+              mParams.rightIndents);
         } catch (IndexOutOfBoundsException e) {
           // Workaround for https://code.google.com/p/android/issues/detail?id=35412
           if (!(mParams.text instanceof String)) {

--- a/library/src/test/java/com/facebook/fbui/textlayoutbuilder/TextLayoutBuilderTest.java
+++ b/library/src/test/java/com/facebook/fbui/textlayoutbuilder/TextLayoutBuilderTest.java
@@ -171,6 +171,32 @@ public class TextLayoutBuilderTest {
   }
 
   @Test
+  public void testSetBreakStrategy() {
+    mLayout = mBuilder.setBreakStrategy(1).build();
+    assertEquals(mBuilder.getBreakStrategy(), 1);
+  }
+
+  @Test
+  public void testSetHyphenationFrequency() {
+    mLayout = mBuilder.setHyphenationFrequency(1).build();
+    assertEquals(mBuilder.getHyphenationFrequency(), 1);
+  }
+
+  @Test
+  public void testSetLeftIndents() {
+    int[] leftIndents = new int[] {0, 1};
+    mLayout = mBuilder.setIndents(leftIndents, null).build();
+    assertEquals(mBuilder.getLeftIndents(), leftIndents);
+  }
+
+  @Test
+  public void testSetRightIndents() {
+    int[] rightIndents = new int[] {0, 1};
+    mLayout = mBuilder.setIndents(null, rightIndents).build();
+    assertEquals(mBuilder.getRightIndents(), rightIndents);
+  }
+
+  @Test
   public void testSetGlyphWarmer() {
     FakeGlyphWarmer glyphWarmer = new FakeGlyphWarmer();
     mLayout = mBuilder.setGlyphWarmer(glyphWarmer).build();


### PR DESCRIPTION
Summary:
This uses the new StaticLayout.Builder API on 23+.
This allows us to expose break strategy, hyphenation and indentation for the layouts.
Also, bumped the proxy to 1.1 as new API is exposed now.

Test Plan:
Tested the getters and setters.
Tested the new API in a sample app and it works as expected.