### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/library/src/main/java/com/facebook/fbui/textlayoutbuilder/TextLayoutBuilder.java
+++ b/library/src/main/java/com/facebook/fbui/textlayoutbuilder/TextLayoutBuilder.java
@@ -249,7 +249,8 @@ public class TextLayoutBuilder {
         text.hashCode();
       } catch (NullPointerException e) {
         throw new IllegalArgumentException(
-            "The given text contains a null span. Due to an Android framework bug, this will cause an exception later down the line.",
+            "The given text contains a null span. Due to an Android framework bug, this will cause"
+                + " an exception later down the line.",
             e);
       }
     }
@@ -962,7 +963,9 @@ public class TextLayoutBuilder {
     return this;
   }
 
-  /** @return The density of this layout. If unset, defaults to 1.0 */
+  /**
+   * @return The density of this layout. If unset, defaults to 1.0
+   */
   public float getDensity() {
     return mParams.paint.density;
   }
@@ -982,7 +985,9 @@ public class TextLayoutBuilder {
     return this;
   }
 
-  /** @return The justification mode of this layout. */
+  /**
+   * @return The justification mode of this layout.
+   */
   @RequiresApi(api = Build.VERSION_CODES.O)
   public int getJustificationMode() {
     return mParams.justificationMode;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


